### PR TITLE
Update csp.go

### DIFF
--- a/pkg/csprecon/csp.go
+++ b/pkg/csprecon/csp.go
@@ -1,19 +1,16 @@
-/*
-csprecon - Discover new target domains using Content Security Policy
-
-This repository is under MIT License https://github.com/edoardottt/csprecon/blob/main/LICENSE
-*/
-
 package csprecon
 
 import (
+	"bytes"
 	"crypto/tls"
+	"fmt"
 	"io"
-	"log"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
@@ -31,63 +28,99 @@ const (
 
 // CheckCSP returns the list of domains parsed from a URL found in CSP.
 func CheckCSP(url, ua string, rCSP *regexp.Regexp, client *http.Client) ([]string, error) {
-	result := []string{}
+    result := []string{}
+    gologger.Debug().Msgf("Checking CSP for %s", url)
+    
+    req, err := http.NewRequest(http.MethodGet, url, nil)
+    if err != nil {
+        return result, fmt.Errorf("error creating request: %v", err)
+    }
+    req.Header.Add("User-Agent", ua)
+    
+    resp, err := client.Do(req)
+    if err != nil {
+        return result, fmt.Errorf("error making request: %v", err)
+    }
+    defer resp.Body.Close()
+    
+    gologger.Debug().Msgf("Response status: %s", resp.Status)
+    
+    // Check Content-Security-Policy header
+    cspHeader := resp.Header.Get("Content-Security-Policy")
+    if cspHeader != "" {
+        headerCSP := ParseCSP(cspHeader, rCSP)
+        gologger.Debug().Msgf("CSP Header domains: %v", headerCSP)
+        result = append(result, headerCSP...)
+    } else {
+        gologger.Debug().Msg("No Content-Security-Policy header found")
+    }
 
-	gologger.Debug().Msgf("Checking CSP for %s", url)
+    // Check Content-Security-Portal header
+    portalHeader := resp.Header.Get("Content-Security-Portal")
+    if portalHeader != "" {
+        portalCSP := ParseCSP(portalHeader, rCSP)
+        gologger.Debug().Msgf("Content-Security-Portal Header domains: %v", portalCSP)
+        result = append(result, portalCSP...)
+    } else {
+        gologger.Debug().Msg("No Content-Security-Portal header found")
+    }
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return result, err
-	}
-
-	req.Header.Add("User-Agent", ua)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return result, err
-	}
-
-	defer resp.Body.Close()
-
-	headerCSP := ParseCSP(resp.Header.Get("Content-Security-Policy"), rCSP)
-	result = append(result, headerCSP...)
-
-	bodyCSP := ParseBodyCSP(resp.Body, rCSP)
-	result = append(result, bodyCSP...)
-
-	return result, nil
+    bodyCSP, err := ParseBodyCSP(resp.Body, rCSP)
+    if err != nil {
+        gologger.Warning().Msgf("Error parsing body: %v", err)
+    } else {
+        gologger.Debug().Msgf("Body CSP domains: %v", bodyCSP)
+        result = append(result, bodyCSP...)
+    }
+    
+    gologger.Debug().Msgf("Total domains found: %d", len(result))
+    return result, nil
 }
 
 // ParseCSP returns the list of domains parsed from a raw CSP (string).
 func ParseCSP(input string, r *regexp.Regexp) []string {
-	result := []string{}
-
-	matches := r.FindAllStringSubmatch(input, -1)
-	for _, match := range matches {
-		result = append(result, match...)
-	}
-
-	return golazy.RemoveDuplicateValues(result)
+    result := []string{}
+    matches := r.FindAllStringSubmatch(input, -1)
+    for _, match := range matches {
+        if len(match) > 0 {
+            domain := match[0]
+            // Strip "*." from the beginning of the domain
+            domain = strings.TrimPrefix(domain, "*.")
+            result = append(result, domain)
+        }
+    }
+    return golazy.RemoveDuplicateValues(result)
 }
 
 // ParseBodyCSP returns the list of domains parsed from the CSP found in the meta tag
 // of the input HTML body.
-func ParseBodyCSP(body io.Reader, rCSP *regexp.Regexp) []string {
-	result := []string{}
+func ParseBodyCSP(body io.Reader, rCSP *regexp.Regexp) ([]string, error) {
+    result := []string{}
 
-	doc, err := goquery.NewDocumentFromReader(body)
-	if err != nil {
-		log.Fatal(err)
-	}
+    bodyBytes, err := ioutil.ReadAll(body)
+    if err != nil {
+        return nil, fmt.Errorf("error reading body: %v", err)
+    }
 
-	doc.Find("meta[http-equiv='Content-Security-Policy']").Each(func(i int, s *goquery.Selection) {
-		contentCSP := s.AttrOr("content", "")
-		if contentCSP != "" {
-			result = ParseCSP(contentCSP, rCSP)
-		}
-	})
+    doc, err := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))
+    if err != nil {
+        return nil, fmt.Errorf("error parsing HTML: %v", err)
+    }
 
-	return result
+    doc.Find("meta[http-equiv]").Each(func(i int, s *goquery.Selection) {
+        httpEquiv := s.AttrOr("http-equiv", "")
+        content := s.AttrOr("content", "")
+
+        if httpEquiv == "Content-Security-Policy" || httpEquiv == "Content-Security-Portal" {
+            if content != "" {
+                parsed := ParseCSP(content, rCSP)
+                gologger.Debug().Msgf("Found %s in meta tag: %v", httpEquiv, parsed)
+                result = append(result, parsed...)
+            }
+        }
+    })
+
+    return result, nil
 }
 
 func customClient(options *input.Options) (*http.Client, error) {


### PR DESCRIPTION
Fetching domains from `Content-Security-Portal` header and also strip `*.` from results.